### PR TITLE
Fix release build crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     [
         .package(
             url: "https://github.com/chipjarred/SwizzleHelper.git",
-            .branch("FixReleaseBuildCrash")
+            .branch("main")
         )
     ],
     targets:

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     [
         .package(
             url: "https://github.com/chipjarred/SwizzleHelper.git",
-            .branch("main")
+            .branch("FixReleaseBuildCrash")
         )
     ],
     targets:

--- a/Sources/CustomToolTip/NSView+CustomToolTip.swift
+++ b/Sources/CustomToolTip/NSView+CustomToolTip.swift
@@ -431,41 +431,7 @@ public extension NSView
             with: event
         )
     }
-    
-    // MARK:- Swizzled method forwarding
-    // -------------------------------------
-    /**
-     Call the old implementation that takes no parameters, if it exists for a
-     `selector` that has been replaced by swizzling.
-     
-     - Parameter selector: The `selector` whose previous implementation is to
-        be called
-     */
-    private func callReplacedMethod(for selector: Selector)
-    {
-        if let imp = Self.implementation(for: selector) {
-            callIMP(imp, self, selector)
-        }
-    }
-    
-    // -------------------------------------
-    /**
-     Call the old implementation that takes an `NSEvent` parameter, if it
-     exists for a `selector` that has been replaced by swizzling.
-     
-     - Parameters:
-        - selector: The `selector` whose previous implementation is to be called
-        - event: The `NSEvent` to be forwarded to the previous implementation.
-     */
-    private func callReplacedEventMethod(
-        for selector: Selector,
-        with event: NSEvent)
-    {
-        if let imp = Self.implementation(for: selector) {
-            callIMP_withObject(imp, self, selector, event)
-        }
-    }
-    
+        
     // MARK:- Swizzle initialization
     // -------------------------------------
     /**


### PR DESCRIPTION
Moved callReplacedMethod to NSObject extension in SwizzleHelper.