### PR TITLE
Improved the way I determine the mouse cursor rect for displaying a t…

### DIFF
--- a/Sources/CustomToolTip/NSBitmapImageRep+Extension.swift
+++ b/Sources/CustomToolTip/NSBitmapImageRep+Extension.swift
@@ -1,0 +1,124 @@
+import AppKit
+
+// -------------------------------------
+internal extension NSBitmapImageRep
+{
+    /*
+     It's not clear to me if alphaFirst means ABGR or ARGB, and Apple's docs
+     are no help so far, so I implement it both ways, and will just see what
+     results I get.
+     */
+    fileprivate static var alphaFirstMeansABGRNotARGB: Bool { true }
+    
+    // -------------------------------------
+    struct RGBAPixel
+    {
+        var red, green, blue, alpha: CGFloat
+        
+        // -------------------------------------
+        fileprivate mutating func toAlphaFirst()
+        {
+            if NSBitmapImageRep.alphaFirstMeansABGRNotARGB
+            {
+                swap(&red, &alpha)
+                swap(&green, &blue)
+            }
+            else
+            {
+                let tempAlpha = alpha
+                alpha = blue
+                blue = green
+                green = red
+                red = tempAlpha
+            }
+        }
+    }
+    
+    // -------------------------------------
+    var rgbaPixels: [RGBAPixel]?
+    {
+        guard samplesPerPixel == 4,
+            let components = cgFloatValues
+        else { return nil }
+        
+        var pixels = [RGBAPixel]()
+        pixels.reserveCapacity(components.count / 4)
+        
+        var i = 0
+        while i < components.count
+        {
+            pixels.append(
+                .init(
+                    red: components[i],
+                    green: components[i+1],
+                    blue: components[i+2],
+                    alpha: components[i+3]
+                )
+            )
+            i += 4
+        }
+        
+        if bitmapFormat.contains(.alphaFirst) {
+            pixels.indices.forEach { pixels[$0].toAlphaFirst() }
+        }
+        
+        return pixels
+    }
+    
+    // -------------------------------------
+    private var cgFloatValues: [CGFloat]?
+    {
+        if bitmapFormat.contains(.floatingPointSamples)
+        {
+            /*
+             NOTE: big endian formats are specifically supported for integer
+             types, but is missing for float.  Does that mean bitmap floats are
+             never big endian in bitmaps?  Also are they actually Float or
+             Double?
+             */
+            return mapToCGFloats { (x: Float) -> CGFloat in CGFloat(x) }
+        }
+        else if bitmapFormat.contains(.thirtyTwoBitLittleEndian)
+        {
+            let divisor = CGFloat(UInt32.max)
+            return mapToCGFloats {
+                (x: UInt32) -> CGFloat in CGFloat(x) / divisor
+            }
+        }
+        else if bitmapFormat.contains(.sixteenBitLittleEndian)
+        {
+            let divisor = CGFloat(UInt16.max)
+            return mapToCGFloats {
+                (x: UInt16) -> CGFloat in CGFloat(x) / divisor
+            }
+        }
+        else if bitmapFormat.contains(.thirtyTwoBitBigEndian)
+        {
+            let divisor = CGFloat(UInt32.max)
+            return mapToCGFloats {
+                (x: UInt32) -> CGFloat in CGFloat(x.byteSwapped) / divisor
+            }
+        }
+        else if bitmapFormat.contains(.sixteenBitBigEndian)
+        {
+            let divisor = CGFloat(UInt16.max)
+            return mapToCGFloats {
+                (x: UInt16) -> CGFloat in CGFloat(x.byteSwapped) / divisor
+            }
+        }
+        
+        let divisor = CGFloat(UInt8.max)
+        return mapToCGFloats { (x: UInt8) -> CGFloat in CGFloat(x) / divisor }
+    }
+    
+    // -------------------------------------
+    private func mapToCGFloats<T>(
+        using convert: (T) -> CGFloat) -> [CGFloat]?
+    {
+        guard let bytes = bitmapData else { return nil }
+        
+        let numBytes = 4 * pixelsWide * pixelsHigh * MemoryLayout<T>.stride
+        return UnsafeMutableBufferPointer(start: bytes, count: numBytes)
+            .withMemoryRebound(to: T.self) {  $0.map { convert($0) } }
+    }
+}

--- a/Sources/CustomToolTip/NSImage+Extension.swift
+++ b/Sources/CustomToolTip/NSImage+Extension.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+// -------------------------------------
+internal extension NSImage
+{
+    // -------------------------------------
+    /**
+     The smallest `CGRect` that can encompass all of the pixels where
+     `alpha` > `alphaThreshold`
+     */
+    func minMaskRect(alphaThreshold: CGFloat) -> CGRect?
+    {
+        guard let c = cgImage(forProposedRect: nil, context: nil, hints: nil)
+        else { return nil }
+        
+        let bitMap = NSBitmapImageRep(cgImage: c)
+        
+        guard let pixels = bitMap.rgbaPixels else { return nil }
+        
+        var minX: Int = Int.max
+        var minY: Int = Int.max
+        var maxX: Int = Int.min
+        var maxY: Int = Int.min
+        
+        for y in 0..<bitMap.pixelsHigh
+        {
+            for x in 0..<bitMap.pixelsWide
+            {
+                let pixel = pixels[y * bitMap.pixelsWide + x]
+                
+                if pixel.alpha > alphaThreshold
+                {
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                }
+            }
+        }
+        
+        return CGRect(
+            x: CGFloat(minX),
+            y: CGFloat(minY),
+            width: CGFloat(maxX - minX + 1),
+            height: CGFloat(maxY - minY + 1)
+        )
+    }
+}


### PR DESCRIPTION
…ool tip relative to it.  Since Apple doesn't provide an API to get that info, I was relying on a bunch of special cases based on trial and error experimentation.  I still have those as a fall back, but if it's `image` can be expressed as an RGBA bitmap (or ABGR or ARGB) I analyze it to find the minimum rectangle that completely encloses the non-transparent portions.  That gives me a provably correct CGRect to work with.